### PR TITLE
Avoid format-security error.

### DIFF
--- a/MeCab_wrap.cpp
+++ b/MeCab_wrap.cpp
@@ -1210,7 +1210,7 @@ SWIG_Ruby_AppendOutput(VALUE target, VALUE o) {
 /* Error manipulation */
 
 #define SWIG_ErrorType(code)                            SWIG_Ruby_ErrorType(code)               
-#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), msg)
+#define SWIG_Error(code, msg)            		rb_raise(SWIG_Ruby_ErrorType(code), "%s", msg)
 #define SWIG_fail                        		goto fail				 
 
 


### PR DESCRIPTION
When compiling with `-Werror=format-security`, errors like the following occur.

```
MeCab_wrap.cpp:1213:83: error: format not a string literal and no format arguments [-Werror=format-security]
 #define SWIG_Error(code, msg)              rb_raise(SWIG_Ruby_ErrorType(code), msg)
```

This PR fixes this problem.

@mrkn Please review. (cc: @sorah )
